### PR TITLE
Make `Key` public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ mod util;
 pub mod rudymap;
 mod key;
 
-use key::Key;
+pub use key::Key;
 //mod rudyset;
 
 //pub use rudyset::RudySet;


### PR DESCRIPTION
It is actually part of the `RudyMap` interface, so it should be public.