### PR TITLE
Turn RootPtr to NonZero

### DIFF
--- a/src/rudymap/rootptr.rs
+++ b/src/rudymap/rootptr.rs
@@ -58,11 +58,8 @@ macro_rules! impl_root_ptr {
                               type_code, TYPE_CODE_MASK!());
                 debug_assert_eq!(ptr as usize & TYPE_CODE_MASK!(), 0,
                               "Low bits of root ptr {:?} are set", ptr);
-                let encoded = ptr as usize | type_code;
-                debug_assert!(encoded != 0,
-                              "Encoded root ptr was a zero");
                 RootPtr {
-                    word: NonZeroUsize::new(encoded),
+                    word: NonZeroUsize::new(ptr as usize | type_code),
                     phantomdata: PhantomData
                 }
             }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -10,6 +10,7 @@ pub struct NonZeroUsize(&'static ());
 impl NonZeroUsize {
     #[inline]
     pub unsafe fn new(value: usize) -> Self {
+        debug_assert!(value != 0, "usize was zero");
         NonZeroUsize(&*(value as *const ()))
     }
 

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -3,6 +3,22 @@ use std::cmp::Ordering;
 
 pub mod locksteparray;
 
+// TODO: Replace with `NonZero` when and if it stabilizes: rust-lang/rust#27730
+#[derive(Copy, Clone)]
+pub struct NonZeroUsize(&'static ());
+
+impl NonZeroUsize {
+    #[inline]
+    pub unsafe fn new(value: usize) -> Self {
+        NonZeroUsize(&*(value as *const ()))
+    }
+
+    #[inline]
+    pub fn get(self) -> usize {
+        self.0 as *const () as usize
+    }
+}
+
 pub fn partial_read(array: &[u8]) -> usize {
     debug_assert!(array.len() <= size_of::<usize>());
     array.iter()


### PR DESCRIPTION
This PR turns `RootPtr` to `NonZero` by [abusing](https://github.com/rust-lang/rust/issues/27730#issuecomment-311919692) `&'static ()`.