### PR TITLE
Add smoke test

### DIFF
--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -1,0 +1,17 @@
+extern crate rudy;
+
+#[test]
+fn smoke_test() {
+    use rudy::rudymap::RudyMap;
+
+    let mut map: RudyMap<u32, u32> = RudyMap::new();
+    let n = 10_000;
+
+    for i in 0..n {
+        assert!(map.insert(i, i).is_none());
+    }
+
+    for i in 0..n {
+        assert_eq!(map.remove(i), Some(i));
+    }
+}


### PR DESCRIPTION
While attempting to glue `rudy` to `specs` (slide-rs/specs#204), I discovered that this code:

```rust
use rudy::rudymap::RudyMap;

let mut map: RudyMap<u32, u32> = RudyMap::new();
map.insert(0, 0);
map.insert(1, 1);
map.insert(2, 2);
map.insert(3, 3);
```

fails with:

```
thread 'smoke_test' panicked at 'Unexpected insertion overflow', src/rudymap/results.rs:15:39
```

I packed linear insertion/removal into a rudimentary smoke test, which currently fails.