### PR TITLE
Update LeafBitmap drop to use drop_in_place()

### DIFF
--- a/src/rudymap/jpm/leaf_bitmap.rs
+++ b/src/rudymap/jpm/leaf_bitmap.rs
@@ -32,8 +32,13 @@ impl<K: Key, V> LeafBitmap<K, V> {
 impl<K: Key, V> Drop for LeafBitmap<K, V> {
     fn drop(&mut self) {
         for index in 0..256 {
-            let key: [u8; 1] = [index as u8];
-            self.remove(&key).success();
+            let occupied = self.keys[index / 8] & (1 << (index % 8));
+            if occupied != 0 {
+                let mut value = &mut self.values[index];
+                unsafe {
+                    ptr::drop_in_place(value as *mut V);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
I saw the note on #4, and figured I'd loop back to it. `LeafBitmap::drop()` now walks keys directly and uses `std::ptr::drop_in_place()` instead of hoping that the compiler inlines `remove()` and optimizes it into something similar.