### PR TITLE
Inline Index::as_usize()

### DIFF
--- a/src/util/locksteparray.rs
+++ b/src/util/locksteparray.rs
@@ -33,10 +33,12 @@ pub trait Index : Unsigned + ops::AddAssign + ops::SubAssign + Copy {
 macro_rules! impl_index {
     ($index_type:ty) => (
         impl Index for $index_type {
+            #[inline(always)]
             fn as_usize(self) -> usize {
                 self as usize
             }
 
+            #[inline(always)]
             fn from_usize(value: usize) -> Self {
                 value as $index_type
             }


### PR DESCRIPTION
I saw `util::locksteparray::Index::as_usize()` pop up in some profiler output in a place where I didn't think that should matter, so I added `#[inline(always)]`. That obviously made the call vanish from the profiler output, but it also improved the benchmarks.

Before:

```
test rudymap_find_existing     ... bench:      26,501 ns/iter (+/- 5,358)
test rudymap_find_existing     ... bench:      27,782 ns/iter (+/- 9,235)
test rudymap_find_existing     ... bench:      26,330 ns/iter (+/- 2,462)
test rudymap_find_existing     ... bench:      26,742 ns/iter (+/- 3,441)
test rudymap_find_existing     ... bench:      27,537 ns/iter (+/- 5,810)
```

After:

```
test rudymap_find_existing     ... bench:      20,880 ns/iter (+/- 3,969)
test rudymap_find_existing     ... bench:      19,898 ns/iter (+/- 4,214)
test rudymap_find_existing     ... bench:      19,462 ns/iter (+/- 977)
test rudymap_find_existing     ... bench:      19,322 ns/iter (+/- 7,073)
test rudymap_find_existing     ... bench:      19,356 ns/iter (+/- 2,566)
```