### PR TITLE
Add memory_usage() functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ types and the usage of larger types, with possible impact to performance.
 - [x] Insertion
 - [x] Get
 - [x] Remove
-- [ ] Memory used
+- [x] Memory used
 - [ ] Shrink
 - [ ] Iterators
 

--- a/src/rudymap/jpm/branch_bitmap.rs
+++ b/src/rudymap/jpm/branch_bitmap.rs
@@ -4,6 +4,7 @@ use super::traits::JpmNode;
 use ::rudymap::results::{InsertResult, RemoveResult};
 use super::branch_uncompressed::BranchUncompressed;
 use std::iter::FromIterator;
+use std::mem;
 
 struct Subexpanse<K: Key, V> {
     pub bitmap: u32,
@@ -72,6 +73,18 @@ impl<K: Key, V> Subexpanse<K, V> {
             .remove(subkey);
         RemoveResult::Success(evicted)
     }
+
+    pub fn memory_usage(&self) -> usize {
+        let mut bytes = mem::size_of::<Self>();
+        if let Some(ref inner_ptrs) = self.ptr {
+            for i in 0..32 as usize {
+                if (self.bitmap & (1 << i)) as u32 != 0 {
+                    bytes += inner_ptrs[i].memory_usage();
+                }
+            }
+        }
+        bytes
+    }
 }
 
 pub struct BranchBitmap<K: Key, V> {
@@ -109,6 +122,14 @@ impl<K: Key, V> JpmNode<K, V> for BranchBitmap<K, V> {
 
     fn shrink_remove(self, pop: usize, key: &[u8]) -> (InnerPtr<K, V>, V) {
         unreachable!()
+    }
+
+    fn memory_usage(&self) -> usize {
+        let mut bytes = mem::size_of::<Self>();
+        for i in 0..32 as usize {
+            bytes += self.subexpanses[i].memory_usage();
+        }
+        bytes
     }
 }
 

--- a/src/rudymap/jpm/branch_bitmap.rs
+++ b/src/rudymap/jpm/branch_bitmap.rs
@@ -79,7 +79,7 @@ impl<K: Key, V> Subexpanse<K, V> {
         if let Some(ref inner_ptrs) = self.ptr {
             for i in 0..32 as usize {
                 if (self.bitmap & (1 << i)) as u32 != 0 {
-                    bytes += inner_ptrs[i].memory_usage();
+                    bytes += inner_ptrs[i].target_memory_usage();
                 }
             }
         }

--- a/src/rudymap/jpm/branch_linear.rs
+++ b/src/rudymap/jpm/branch_linear.rs
@@ -7,6 +7,7 @@ use super::traits::JpmNode;
 use ::rudymap::results::{InsertResult, RemoveResult};
 use super::branch_bitmap::BranchBitmap;
 use std::iter::FromIterator;
+use std::mem;
 
 pub struct BranchLinear<K: Key, V> {
     array: LockstepArray<[u8; 7], [InnerPtr<K, V>; 7]>
@@ -86,6 +87,13 @@ impl<K: Key, V> JpmNode<K, V> for BranchLinear<K, V> {
         unreachable!()
     }
 
+    fn memory_usage(&self) -> usize {
+        let mut bytes = mem::size_of::<Self>();
+        for jpm in self.array.array2().iter() {
+            bytes += jpm.memory_usage();
+        }
+        bytes
+    }
 }
 
 impl<K: Key, V> FromIterator<(u8, InnerPtr<K, V>)> for BranchLinear<K, V> {

--- a/src/rudymap/jpm/branch_linear.rs
+++ b/src/rudymap/jpm/branch_linear.rs
@@ -90,7 +90,7 @@ impl<K: Key, V> JpmNode<K, V> for BranchLinear<K, V> {
     fn memory_usage(&self) -> usize {
         let mut bytes = mem::size_of::<Self>();
         for jpm in self.array.array2().iter() {
-            bytes += jpm.memory_usage();
+            bytes += jpm.target_memory_usage();
         }
         bytes
     }

--- a/src/rudymap/jpm/branch_uncompressed.rs
+++ b/src/rudymap/jpm/branch_uncompressed.rs
@@ -55,4 +55,11 @@ impl<K: Key, V> JpmNode<K, V> for BranchUncompressed<K, V> {
         unreachable!()
     }
 
+    fn memory_usage(&self) -> usize {
+        let mut bytes = mem::size_of::<Self>();
+        for jpm in self.array.iter() {
+            bytes += jpm.memory_usage();
+        }
+        bytes
+    }
 }

--- a/src/rudymap/jpm/branch_uncompressed.rs
+++ b/src/rudymap/jpm/branch_uncompressed.rs
@@ -58,7 +58,7 @@ impl<K: Key, V> JpmNode<K, V> for BranchUncompressed<K, V> {
     fn memory_usage(&self) -> usize {
         let mut bytes = mem::size_of::<Self>();
         for jpm in self.array.iter() {
-            bytes += jpm.memory_usage();
+            bytes += jpm.target_memory_usage();
         }
         bytes
     }

--- a/src/rudymap/jpm/empty.rs
+++ b/src/rudymap/jpm/empty.rs
@@ -57,4 +57,8 @@ impl<K: Key, V> JpmNode<K, V> for Empty<K, V> {
     fn shrink_remove(self, pop: usize, key: &[u8]) -> (InnerPtr<K, V>, V) {
         unreachable!();
     }
+
+    fn memory_usage(&self) -> usize {
+        0
+    }
 }

--- a/src/rudymap/jpm/innerptr.rs
+++ b/src/rudymap/jpm/innerptr.rs
@@ -8,6 +8,7 @@ use super::traits::JpmNode;
 use ::rudymap::results::{InsertResult, RemoveResult};
 use ::util::{partial_write, partial_read};
 use ::Key;
+use std::mem;
 
 #[cfg(target_pointer_width = "32")]
 pub struct Population {
@@ -156,6 +157,16 @@ macro_rules! make_inner_ptr {
 
             pub fn take(&mut self) -> InnerPtr<K, V> {
                 ::std::mem::replace(self, InnerPtr::default())
+            }
+
+            pub fn memory_usage(&self) -> usize {
+                match *self {
+                    $(
+                        InnerPtr::$type(ref target, ref pop) => {
+                            target.memory_usage() + mem::size_of_val(pop)
+                        },
+                    )*
+                }
             }
         }
 

--- a/src/rudymap/jpm/innerptr.rs
+++ b/src/rudymap/jpm/innerptr.rs
@@ -159,11 +159,18 @@ macro_rules! make_inner_ptr {
                 ::std::mem::replace(self, InnerPtr::default())
             }
 
-            pub fn memory_usage(&self) -> usize {
+            // In general, an `InnerPtr` or array of `InnerPtr`s will be included in some other data
+            // structure which already counts its own size in a `memory_usage()` function. Thus, it
+            // is not useful for `InnerPtr` to report its own memory consumption.
+            //
+            // However, it _is_ useful to ask an `InnerPtr` about the memory consumption of its
+            // target without including the `InnerPtr` itself. This is what `target_memory_usage()`
+            // does.
+            pub fn target_memory_usage(&self) -> usize {
                 match *self {
                     $(
-                        InnerPtr::$type(ref target, ref pop) => {
-                            target.memory_usage() + mem::size_of_val(pop)
+                        InnerPtr::$type(ref target, ref _pop) => {
+                            target.memory_usage()
                         },
                     )*
                 }

--- a/src/rudymap/jpm/jpm_root.rs
+++ b/src/rudymap/jpm/jpm_root.rs
@@ -1,4 +1,5 @@
 use std::iter::FromIterator;
+use std::mem;
 use rudymap::root_leaf::RootLeaf;
 use super::innerptr::InnerPtr;
 use super::traits::JpmNode;
@@ -52,6 +53,9 @@ impl<K: Key, V> RootLeaf<K, V> for Jpm<K, V> {
 
     fn len(&self) -> usize {
         self.len
+    }
+    fn memory_usage(&self) -> usize {
+        mem::size_of::<Self>() + self.head.memory_usage()
     }
 }
 

--- a/src/rudymap/jpm/jpm_root.rs
+++ b/src/rudymap/jpm/jpm_root.rs
@@ -55,7 +55,7 @@ impl<K: Key, V> RootLeaf<K, V> for Jpm<K, V> {
         self.len
     }
     fn memory_usage(&self) -> usize {
-        mem::size_of::<Self>() + self.head.memory_usage()
+        mem::size_of::<Self>() + self.head.target_memory_usage()
     }
 }
 

--- a/src/rudymap/jpm/leaf_linear.rs
+++ b/src/rudymap/jpm/leaf_linear.rs
@@ -49,4 +49,6 @@ impl<K: Key, V> JpmNode<K, V> for LeafLinear<K, V> {
     fn shrink_remove(self, pop: usize, key: &[u8]) -> (InnerPtr<K, V>, V) {
         unreachable!()
     }
+
+    fn memory_usage(&self) -> usize {  unimplemented!()  }
 }

--- a/src/rudymap/jpm/traits.rs
+++ b/src/rudymap/jpm/traits.rs
@@ -10,4 +10,5 @@ pub trait JpmNode<K: Key, V> {
     fn expand(self, population: usize, key: &[u8], value: V) -> InnerPtr<K, V>;
     fn remove(&mut self, key: &[u8]) -> RemoveResult<V>;
     fn shrink_remove(self, pop: usize, key: &[u8]) -> (InnerPtr<K, V>, V);
+    fn memory_usage(&self) -> usize;
 }

--- a/src/rudymap/mod.rs
+++ b/src/rudymap/mod.rs
@@ -62,6 +62,10 @@ impl<K: Key, V> RudyMap<K, V> {
         IterMut::new(&mut self.root)
     }
     */
+
+    pub fn memory_usage(&self) -> usize {
+        self.root.memory_usage()
+    }
 }
 
 impl<K: Key, V> Default for RudyMap<K, V> {

--- a/src/rudymap/root_leaf.rs
+++ b/src/rudymap/root_leaf.rs
@@ -17,7 +17,10 @@ pub trait RootLeaf<K: Key, V> {
     fn remove(&mut self, key: K) -> RemoveResult<V>;
     fn shrink_remove(self, key: K) -> (RootPtr<K, V>, V);
     fn len(&self) -> usize;
-    fn memory_usage(&self) -> usize;
+
+    fn memory_usage(&self) -> usize {
+        mem::size_of_val(self)
+    }
 }
 
 pub struct Empty<K: Key, V>(PhantomData<(K, V)>);
@@ -56,8 +59,6 @@ impl<K: Key, V> RootLeaf<K, V> for Empty<K, V> {
     fn len(&self) -> usize {
         0
     }
-
-    fn memory_usage(&self) -> usize { 0 }
 }
 
 impl<K: Key, V> Default for Empty<K, V> {
@@ -140,10 +141,6 @@ impl<K: Key, V> RootLeaf<K, V> for Leaf1<K, V> {
 
     fn len(&self) -> usize {
         1
-    }
-
-    fn memory_usage(&self) -> usize {
-        mem::size_of_val(self)
     }
 }
 
@@ -228,9 +225,6 @@ impl<K: Key, V> RootLeaf<K, V> for Leaf2<K, V> {
 
     fn len(&self) -> usize {
         2
-    }
-    fn memory_usage(&self) -> usize {
-        mem::size_of_val(self)
     }
 }
 
@@ -317,8 +311,5 @@ impl<K: Key, V> RootLeaf<K, V> for VecLeaf<K, V> {
 
     fn len(&self) -> usize {
         self.array.len()
-    }
-    fn memory_usage(&self) -> usize {
-        mem::size_of_val(self)
     }
 }

--- a/src/rudymap/root_leaf.rs
+++ b/src/rudymap/root_leaf.rs
@@ -17,6 +17,7 @@ pub trait RootLeaf<K: Key, V> {
     fn remove(&mut self, key: K) -> RemoveResult<V>;
     fn shrink_remove(self, key: K) -> (RootPtr<K, V>, V);
     fn len(&self) -> usize;
+    fn memory_usage(&self) -> usize;
 }
 
 pub struct Empty<K: Key, V>(PhantomData<(K, V)>);
@@ -55,6 +56,8 @@ impl<K: Key, V> RootLeaf<K, V> for Empty<K, V> {
     fn len(&self) -> usize {
         0
     }
+
+    fn memory_usage(&self) -> usize { 0 }
 }
 
 impl<K: Key, V> Default for Empty<K, V> {
@@ -137,6 +140,10 @@ impl<K: Key, V> RootLeaf<K, V> for Leaf1<K, V> {
 
     fn len(&self) -> usize {
         1
+    }
+
+    fn memory_usage(&self) -> usize {
+        mem::size_of_val(self)
     }
 }
 
@@ -221,6 +228,9 @@ impl<K: Key, V> RootLeaf<K, V> for Leaf2<K, V> {
 
     fn len(&self) -> usize {
         2
+    }
+    fn memory_usage(&self) -> usize {
+        mem::size_of_val(self)
     }
 }
 
@@ -307,5 +317,8 @@ impl<K: Key, V> RootLeaf<K, V> for VecLeaf<K, V> {
 
     fn len(&self) -> usize {
         self.array.len()
+    }
+    fn memory_usage(&self) -> usize {
+        mem::size_of_val(self)
     }
 }

--- a/src/rudymap/rootptr.rs
+++ b/src/rudymap/rootptr.rs
@@ -3,6 +3,7 @@ use super::root_leaf::{RootLeaf, Empty, Leaf1, Leaf2, VecLeaf};
 use super::jpm::Jpm;
 use ::Key;
 use std::marker::PhantomData;
+use std::mem;
 use super::results::{InsertResult, RemoveResult};
 use util::NonZeroUsize;
 
@@ -139,6 +140,15 @@ macro_rules! impl_root_ptr {
 
             fn ptr_mut(&self) -> *mut () {
                 (self.word.get() & !TYPE_CODE_MASK!()) as *mut ()
+            }
+
+            pub fn memory_usage(&self) -> usize {
+                match self.as_ref() {
+                    RootRef::Empty(_) => mem::size_of::<Self>(),
+                    $(
+                        RootRef::$type_name(node) => mem::size_of::<Self>() + node.memory_usage(),
+                    )*
+                }
             }
         }
 


### PR DESCRIPTION
So… Judy/Rudy is pretty complicated and I don't have the design entirely committed to memory. I expect some of this is wrong. Please review with that in mind :-)

Would it be worth counting allocations, binning different allocation sizes, or generally being more sophisticated? `memory_usage()` could easily accumulate into a `MemoryUsage` struct instead of summing bytes and returning a `usize`.