### PR TITLE
Add CI code coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,35 @@
 language: rust
 rust:
   - nightly
+
+env:
+  global:
+  - RUSTFLAGS="-C link-dead-code"
+
+before_install:
+  - sudo apt-get update
+
+addons:
+  apt:
+    packages:
+      - libcurl4-openssl-dev
+      - libelf-dev
+      - libdw-dev
+      - cmake
+      - gcc
+      - binutils-dev
+
+after_success: |
+  wget https://github.com/SimonKagstrom/kcov/archive/master.tar.gz &&
+  tar xzf master.tar.gz &&
+  cd kcov-master &&
+  mkdir build &&
+  cd build &&
+  cmake .. &&
+  make &&
+  sudo make install &&
+  cd ../.. &&
+  rm -rf kcov-master &&
+  for file in target/debug/rudy-*[^\.d]; do mkdir -p "target/cov/$(basename $file)"; kcov --exclude-pattern=/.cargo,/usr/lib --verify "target/cov/$(basename $file)" "$file"; done &&
+  bash <(curl -s https://codecov.io/bash) &&
+  echo "Uploaded code coverage"

--- a/src/rudymap/mod.rs
+++ b/src/rudymap/mod.rs
@@ -70,19 +70,84 @@ impl<K: Key, V> Default for RudyMap<K, V> {
     }
 }
 
+#[cfg(test)]
+mod test {
+    use super::*;
 
-#[test]
-fn test_insert_get_1() {
-    let mut map = RudyMap::<usize, usize>::new();
-    map.insert(4usize, 10usize);
-    assert_eq!(map.get(4), Some(&10));
-}
+    #[test]
+    fn test_insert_get_1() {
+        let mut map = RudyMap::<usize, usize>::new();
+        map.insert(4usize, 10usize);
+        assert_eq!(map.get(4), Some(&10));
+    }
 
-#[test]
-fn test_insert_get_2() {
-    let mut map = RudyMap::<usize, usize>::new();
-    map.insert(0usize, 10usize);
-    map.insert(1usize, 20usize);
-    assert_eq!(map.get(0), Some(&10));
-    assert_eq!(map.get(1), Some(&20));
+    #[test]
+    fn test_insert_get_2() {
+        let mut map = RudyMap::<usize, usize>::new();
+        map.insert(0usize, 10usize);
+        map.insert(1usize, 20usize);
+        assert_eq!(map.get(0), Some(&10));
+        assert_eq!(map.get(1), Some(&20));
+    }
+
+    #[test]
+    fn test_contains_key() {
+        let mut map = RudyMap::<u32, u32>::new();
+        assert_eq!(map.contains_key(0), false);
+        assert_eq!(map.contains_key(1), false);
+
+        assert_eq!(map.insert(0, 0), None);
+        assert_eq!(map.contains_key(0), true);
+        assert_eq!(map.contains_key(1), false);
+
+        assert_eq!(map.remove(0), Some(0));
+        assert_eq!(map.contains_key(0), false);
+        assert_eq!(map.contains_key(1), false);
+    }
+
+    #[test]
+    fn test_len() {
+        let mut map = RudyMap::<u32, u32>::new();
+        assert_eq!(map.len(), 0);
+        assert_eq!(map.is_empty(), true);
+
+        assert_eq!(map.insert(0, 0), None);
+        assert_eq!(map.len(), 1);
+        assert_eq!(map.is_empty(), false);
+
+        assert_eq!(map.insert(1, 1), None);
+        assert_eq!(map.len(), 2);
+        assert_eq!(map.is_empty(), false);
+
+        assert_eq!(map.insert(0, 2), Some(0));
+        assert_eq!(map.len(), 2);
+        assert_eq!(map.is_empty(), false);
+
+        assert_eq!(map.remove(0), Some(2));
+        assert_eq!(map.len(), 1);
+        assert_eq!(map.is_empty(), false);
+
+        assert_eq!(map.remove(1), Some(1));
+        assert_eq!(map.len(), 0);
+        assert_eq!(map.is_empty(), true);
+    }
+
+    #[test]
+    fn test_get_mut() {
+        let mut map = RudyMap::<u32, u32>::new();
+        assert!(map.get(0).is_none());
+        assert!(map.get_mut(0).is_none());
+
+        assert_eq!(map.insert(0, 0), None);
+        assert_eq!(map.get(0), Some(&0));
+        assert_eq!(map.get_mut(0), Some(&mut 0));
+        assert_eq!(map.get(1), None);
+        assert_eq!(map.get_mut(1), None);
+
+        *map.get_mut(0).unwrap() += 42;
+        assert_eq!(map.get(0), Some(&42));
+        assert_eq!(map.get_mut(0), Some(&mut 42));
+
+        map.remove(0);
+    }
 }


### PR DESCRIPTION
This changeset changes the Travis CI config to run tests as usual, but assuming `cargo test` passes, it uses `after_success:` to download and build `kcov`, re-runs the test executable to collect code coverage info, and posts it to [codecov.io](https://codecov.io).

Here's [Travis build output](https://travis-ci.org/willglynn/rudy/builds/253982386) and the [codecov coverage report](https://codecov.io/gh/willglynn/rudy/branch/ci_code_coverage) from this branch on my repo if you'd like to see what it looks like. All the `after_success:` stuff is all collapsed on Travis by default, so it's nowhere near as noisy as you might think based on the `.travis.yml`.

You would need to sign up with Codecov before merging, though like Travis, it's free for open source software.

Finally, it's worth noting that while the code coverage data is correct on a line by line basis, the code coverage _statistics_ are incorrect (rust-lang/rust#39293). The coverage information shows which code paths get executed and which do not, but generic functions which were never codegen'd for the test executable do not count against the coverage percentage. For example, [`RudyMap` shows 100% coverage](https://codecov.io/gh/willglynn/rudy/src/ci_code_coverage/src/rudymap/mod.rs)… but the report also indicates that `remove()`, `contains_key()`, `get_mut()`, `len()`, and `is_empty()` are never called.